### PR TITLE
Add launchctl error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
-launchctl
-*.o
-compile_commands.json
+.DS_Store
+
 .cache
+*.o
 *.dylib
+launchctl
+
+compile_commands.json

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PREFIX  ?= 
 DESTIDR ?=
 
-SRC := launchctl.c xpc_helper.c start_stop.c print.c env.c load.c enable.c reboot.c bootstrap.c
+SRC := launchctl.c xpc_helper.c start_stop.c print.c env.c load.c enable.c reboot.c bootstrap.c error.c
 
 all: launchctl
 

--- a/error.c
+++ b/error.c
@@ -35,104 +35,90 @@
 extern const char *bootstrap_strerror(kern_return_t r);
 
 int error_cmd(xpc_object_t *msg, int argc, char **argv, char **envp, char **apple) {
-    int retval = 117;
-    
-    const char *extraMessagesTable[] = {
-        "kernel out-of-line resource shortage",
-        "kernel ipc resource shortage",
-        "unknown",
-        "vm address space shortage",
-        "unknown",
-        "unknown",
-        "unknown",
-        "ipc namespace shortage",
-    };
-    
-    if (argc < 2) {
-        return retval;
-    }
-    
-    const char *arg = argv[1];
-    unsigned long code = 0;
-    int type = 0;
-    
-    if (strcmp(arg, "mach") == 0) {
-        if (argc < 3) {
-            return retval;
-        }
-        
-        code = strtoul(argv[2], NULL, 0);
-        type = 1;
-    }
-    else if (strcmp(arg, "bootstrap") == 0) {
-        if (argc < 3) {
-            return retval;
-        }
-        
-        code = strtoul(argv[2], NULL, 0);
-        type = 2;
-    }
-    else if (strcmp(arg, "posix") == 0) {
-        if (argc < 3) {
-            return retval;
-        }
-        
-        code = strtoul(argv[2], NULL, 0);
-        type = 3;
-    }
-    else {
-        code = strtoul(arg, NULL, 0);
-        if (code < 161) {
-            type = 3;
-        }
-        else {
-            const char *other = "0x";
-            if (strncmp(arg, other, strlen(other)) == 0) {
-                type = 1;
-            }
-            else {
-                type = 2;
-            }
-        }
-    }
-    
-    if (type == 1) {
-        unsigned long extraCode = code & 0x3E00;
-        char *str = mach_error_string((mach_error_t)(code & 0xFFFFC1FF));
-        
-        fprintf(stdout, "0x%lx: %s\n", code, str);
-        fprintf(stdout, "system = 0x%x\n", (unsigned int)err_get_system(code));
-        fprintf(stdout, "subsystem = 0x%x\n", (unsigned int)err_get_sub(code));
-        fprintf(stdout, "code = 0x%x\n", (unsigned int)(code & 0x1FF));
-        
-        if (extraCode != 0) {
-            unsigned long extraCodeIndex = (extraCode - 1024) >> 10;
-            const char *extraStr = NULL;
-            if (extraCodeIndex <= 7) {
-                extraStr = extraMessagesTable[extraCodeIndex];
-            }
-            else {
-                extraStr = "unknown";
-            }
-            
-            fprintf(stdout, "extra = 0x%x: %s\n", (unsigned int)extraCode, extraStr);
-        }
-        
-        retval = 0;
-    }
-    else if (type == 2) {
-        const char *str = bootstrap_strerror((kern_return_t)code);
-        fprintf(stdout, "%u: %s\n", (unsigned int)code, str);
-        retval = 0;
-    }
-    else if (type == 3) {
-        const char *str = xpc_strerror((int)code);
-        fprintf(stdout, "%u: %s\n", (unsigned int)code, str);
-        retval = 0;
-    }
-    else {
-        retval = 0;
-    }
-    
-    return retval;
+	int retval = EUSAGE;
+
+	const char *extraMessagesTable[] = {
+		"kernel out-of-line resource shortage",
+		"kernel ipc resource shortage",
+		"unknown",
+		"vm address space shortage",
+		"unknown",
+		"unknown",
+		"unknown",
+		"ipc namespace shortage",
+	};
+
+	if (argc < 2)
+		return retval;
+
+	const char *arg = argv[1];
+	unsigned long code = 0;
+	int type = 0;
+
+	if (strcmp(arg, "mach") == 0) {
+		if (argc < 3)
+			return retval;
+
+		code = strtoul(argv[2], NULL, 0);
+		type = 1;
+	} else if (strcmp(arg, "bootstrap") == 0) {
+		if (argc < 3)
+			return retval;
+
+		code = strtoul(argv[2], NULL, 0);
+		type = 2;
+	} else if (strcmp(arg, "posix") == 0) {
+		if (argc < 3)
+			return retval;
+
+		code = strtoul(argv[2], NULL, 0);
+		type = 3;
+	} else {
+		code = strtoul(arg, NULL, 0);
+		if (code < 161)
+			type = 3;
+		else {
+			const char *other = "0x";
+			if (strncmp(arg, other, strlen(other)) == 0) {
+				type = 1;
+			} else {
+				type = 2;
+			}
+		}
+	}
+
+	if (type == 1) {
+		unsigned long extraCode = code & 0x3E00;
+		char *str = mach_error_string((mach_error_t)(code & 0xFFFFC1FF));
+
+		fprintf(stdout, "0x%lx: %s\n", code, str);
+		fprintf(stdout, "system = 0x%x\n", (unsigned int)err_get_system(code));
+		fprintf(stdout, "subsystem = 0x%x\n", (unsigned int)err_get_sub(code));
+		fprintf(stdout, "code = 0x%x\n", (unsigned int)(code & 0x1FF));
+
+		if (extraCode != 0) {
+			unsigned long extraCodeIndex = (extraCode - 1024) >> 10;
+			const char *extraStr = NULL;
+			if (extraCodeIndex <= 7)
+				extraStr = extraMessagesTable[extraCodeIndex];
+			else
+				extraStr = "unknown";
+
+			fprintf(stdout, "extra = 0x%x: %s\n", (unsigned int)extraCode, extraStr);
+		}
+
+		retval = 0;
+	} else if (type == 2) {
+		const char *str = bootstrap_strerror((kern_return_t)code);
+		fprintf(stdout, "%u: %s\n", (unsigned int)code, str);
+		retval = 0;
+	} else if (type == 3) {
+		const char *str = xpc_strerror((int)code);
+		fprintf(stdout, "%u: %s\n", (unsigned int)code, str);
+		retval = 0;
+	} else {
+		retval = 0;
+	}
+
+	return retval;
 }

--- a/error.c
+++ b/error.c
@@ -1,0 +1,138 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2022 Procursus Team <team@procurs.us>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <mach/mach.h>
+#include "xpc_private.h"
+
+extern const char *bootstrap_strerror(kern_return_t r);
+
+int error_cmd(xpc_object_t *msg, int argc, char **argv, char **envp, char **apple) {
+    int retval = 117;
+    
+    const char *extraMessagesTable[] = {
+        "kernel out-of-line resource shortage",
+        "kernel ipc resource shortage",
+        "unknown",
+        "vm address space shortage",
+        "unknown",
+        "unknown",
+        "unknown",
+        "ipc namespace shortage",
+    };
+    
+    if (argc < 2) {
+        return retval;
+    }
+    
+    const char *arg = argv[1];
+    unsigned long code = 0;
+    int type = 0;
+    
+    if (strcmp(arg, "mach") == 0) {
+        if (argc < 3) {
+            return retval;
+        }
+        
+        code = strtoul(argv[2], NULL, 0);
+        type = 1;
+    }
+    else if (strcmp(arg, "bootstrap") == 0) {
+        if (argc < 3) {
+            return retval;
+        }
+        
+        code = strtoul(argv[2], NULL, 0);
+        type = 2;
+    }
+    else if (strcmp(arg, "posix") == 0) {
+        if (argc < 3) {
+            return retval;
+        }
+        
+        code = strtoul(argv[2], NULL, 0);
+        type = 3;
+    }
+    else {
+        code = strtoul(arg, NULL, 0);
+        if (code < 161) {
+            type = 3;
+        }
+        else {
+            const char *other = "0x";
+            if (strncmp(arg, other, strlen(other)) == 0) {
+                type = 1;
+            }
+            else {
+                type = 2;
+            }
+        }
+    }
+    
+    if (type == 1) {
+        unsigned long extraCode = code & 0x3E00;
+        char *str = mach_error_string((mach_error_t)(code & 0xFFFFC1FF));
+        
+        fprintf(stdout, "0x%lx: %s\n", code, str);
+        fprintf(stdout, "system = 0x%x\n", (unsigned int)err_get_system(code));
+        fprintf(stdout, "subsystem = 0x%x\n", (unsigned int)err_get_sub(code));
+        fprintf(stdout, "code = 0x%x\n", (unsigned int)(code & 0x1FF));
+        
+        if (extraCode != 0) {
+            unsigned long extraCodeIndex = (extraCode - 1024) >> 10;
+            const char *extraStr = NULL;
+            if (extraCodeIndex <= 7) {
+                extraStr = extraMessagesTable[extraCodeIndex];
+            }
+            else {
+                extraStr = "unknown";
+            }
+            
+            fprintf(stdout, "extra = 0x%x: %s\n", (unsigned int)extraCode, extraStr);
+        }
+        
+        retval = 0;
+    }
+    else if (type == 2) {
+        const char *str = bootstrap_strerror((kern_return_t)code);
+        fprintf(stdout, "%u: %s\n", (unsigned int)code, str);
+        retval = 0;
+    }
+    else if (type == 3) {
+        const char *str = xpc_strerror((int)code);
+        fprintf(stdout, "%u: %s\n", (unsigned int)code, str);
+        retval = 0;
+    }
+    else {
+        retval = 0;
+    }
+    
+    return retval;
+}

--- a/launchctl.c
+++ b/launchctl.c
@@ -62,8 +62,8 @@ static const struct {
 	{ "setenv", "Sets the specified environment variables for all services within the domain.", "<<key> <value>, ...>", setenv_cmd },
 	{ "unsetenv", "Unsets the specified environment variables for all services within the domain.", "<key, ...>", setenv_cmd },
 	{ "getenv", "Gets the value of an environment variable from within launchd.", "<key>", getenv_cmd },
-    { "error", "Prints a description of an error.", NULL, error_cmd },
-    { "variant", "Prints the launchd variant.", NULL, version_cmd },
+	{ "error", "Prints a description of an error.", "[posix|mach|bootstrap] <code>", error_cmd },
+	{ "variant", "Prints the launchd variant.", NULL, version_cmd },
 	{ "version", "Prints the launchd version.", NULL, version_cmd },
 	{ "help", "Prints the usage for a given subcommand.", "<subcommand>", help_cmd }
 };

--- a/launchctl.c
+++ b/launchctl.c
@@ -62,7 +62,8 @@ static const struct {
 	{ "setenv", "Sets the specified environment variables for all services within the domain.", "<<key> <value>, ...>", setenv_cmd },
 	{ "unsetenv", "Unsets the specified environment variables for all services within the domain.", "<key, ...>", setenv_cmd },
 	{ "getenv", "Gets the value of an environment variable from within launchd.", "<key>", getenv_cmd },
-	{ "variant", "Prints the launchd variant.", NULL, version_cmd },
+    { "error", "Prints a description of an error.", NULL, error_cmd },
+    { "variant", "Prints the launchd variant.", NULL, version_cmd },
 	{ "version", "Prints the launchd version.", NULL, version_cmd },
 	{ "help", "Prints the usage for a given subcommand.", "<subcommand>", help_cmd }
 };

--- a/launchctl.h
+++ b/launchctl.h
@@ -58,6 +58,9 @@ cmd_main reboot_cmd;
 cmd_main bootstrap_cmd;
 cmd_main bootout_cmd;
 
+// error.h
+cmd_main error_cmd;
+
 void launchctl_xpc_object_print(xpc_object_t, const char *name, int level);
 int launchctl_send_xpc_to_launchd(uint64_t routine, xpc_object_t msg, xpc_object_t *reply);
 void launchctl_setup_xpc_dict(xpc_object_t dict);

--- a/launchctl.h
+++ b/launchctl.h
@@ -58,7 +58,7 @@ cmd_main reboot_cmd;
 cmd_main bootstrap_cmd;
 cmd_main bootout_cmd;
 
-// error.h
+// error.c
 cmd_main error_cmd;
 
 void launchctl_xpc_object_print(xpc_object_t, const char *name, int level);

--- a/tools/xpchook.c
+++ b/tools/xpchook.c
@@ -38,11 +38,11 @@ typedef xpc_object_t xpc_pipe_t;
 
 kern_return_t
 xpc_pipe_routine(xpc_pipe_t pipe, xpc_object_t request,
-	xpc_object_t *reply);
+	xpc_object_t XPC_GIVES_REFERENCE *reply);
 
 kern_return_t
 hook_xpc_pipe_routine(xpc_pipe_t pipe, xpc_object_t request,
-	xpc_object_t *reply)
+	xpc_object_t XPC_GIVES_REFERENCE *reply)
 {
 	kern_return_t ret = xpc_pipe_routine(pipe, request, reply);
 	char *requeststr = xpc_copy_description(request);
@@ -59,11 +59,11 @@ DYLD_INTERPOSE(hook_xpc_pipe_routine, xpc_pipe_routine);
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= 130000 || __MAC_OS_X_VERSION_MIN_REQUIRED >= 101500
 kern_return_t
 xpc_pipe_routine_with_flags(xpc_pipe_t pipe, xpc_object_t request,
-	xpc_object_t *reply, uint32_t flags);
+	xpc_object_t XPC_GIVES_REFERENCE *reply, uint64_t flags);
 
 kern_return_t
 hook_xpc_pipe_routine_with_flags(xpc_pipe_t pipe, xpc_object_t request,
-	xpc_object_t *reply, uint32_t flags)
+	xpc_object_t XPC_GIVES_REFERENCE *reply, uint64_t flags)
 {
 	kern_return_t ret = xpc_pipe_routine_with_flags(pipe, request, reply, flags);
 	char *requeststr = xpc_copy_description(request);
@@ -80,10 +80,10 @@ DYLD_INTERPOSE(hook_xpc_pipe_routine_with_flags, xpc_pipe_routine_with_flags);
 #endif
 
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= 160000 || __MAC_OS_X_VERSION_MIN_REQUIRED >= 130000
-int _xpc_pipe_interface_routine(xpc_pipe_t pipe, uint64_t request, xpc_object_t msg, xpc_object_t *reply, uint64_t unknown);
+int _xpc_pipe_interface_routine(xpc_pipe_t pipe, uint64_t routine, xpc_object_t msg, xpc_object_t XPC_GIVES_REFERENCE *reply, uint64_t flags);
 
 int
-hook_xpc_pipe_interface_routine(xpc_pipe_t pipe, uint64_t request, xpc_object_t msg, xpc_object_t *reply, uint64_t flags)
+hook_xpc_pipe_interface_routine(xpc_pipe_t pipe, uint64_t routine, xpc_object_t msg, xpc_object_t XPC_GIVES_REFERENCE *reply, uint64_t flags)
 {
 	int ret = _xpc_pipe_interface_routine(pipe, request, msg, reply, flags);
 	fprintf(stderr, "\033[32mREQUEST: %llu\033[m\n", request);

--- a/xpc_helper.c
+++ b/xpc_helper.c
@@ -41,7 +41,7 @@ launchctl_send_xpc_to_launchd(uint64_t routine, xpc_object_t msg, xpc_object_t *
 	xpc_dictionary_set_uint64(msg, "subsystem", 3);
 	xpc_dictionary_set_uint64(msg, "routine", routine);
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_16_0
-	int ret = xpc_pipe_interface_routine(bootstrap_pipe, 0, msg, reply, 0);
+	int ret = _xpc_pipe_interface_routine(bootstrap_pipe, 0, msg, reply, 0);
 #else
 	int ret = xpc_pipe_routine(bootstrap_pipe, msg, reply);
 #endif

--- a/xpc_private.h
+++ b/xpc_private.h
@@ -49,6 +49,7 @@ enum {
 typedef xpc_object_t xpc_pipe_t;
 
 int xpc_pipe_routine(xpc_pipe_t pipe, xpc_object_t message, xpc_object_t XPC_GIVES_REFERENCE *reply);
+int _xpc_pipe_interface_routine(xpc_pipe_t pipe, uint64_t routine, xpc_object_t message, xpc_object_t XPC_GIVES_REFERENCE *reply, uint64_t flags);
 
 const char *xpc_strerror(int);
 


### PR DESCRIPTION
- Adds functionality for `launchctl error`. This is pretty much an exact replica of the stock macOS `launchctl error` from Monterey 12.3.1. I have tested it to the best of my ability, and it seems to indeed be an exact duplicate, but I can't guarantee edge cases. From my experience, though, it works very well. 

- Fixes some definitions of the xpc_pipe_routine() family of functions. 

- Updates the .gitignore to deal with .DS_Store shenanigans. 