### PR TITLE
Use updated action workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,5 @@
-name: build
+name: CI
+
 on:
   push:
     paths:
@@ -21,44 +22,45 @@ on:
 
 jobs:
   build:
+    name: Build
     runs-on: macos-12
     steps:
-    - uses: actions/checkout@v1
-      with:
-        submodules: recursive
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
 
-    - name: setup environment
-      run: |
-        echo "CC=xcrun -sdk iphoneos cc -arch arm64" >> $GITHUB_ENV
-        echo "STRIP=xcrun -sdk iphoneos strip" >> $GITHUB_ENV
-        echo "CFLAGS=-I${HOME}/include -Os -flto=thin -miphoneos-version-min=12.0" >> $GITHUB_ENV
-        echo "LDFLAGS=-Os -flto=thin -miphoneos-version-min=12.0" >> $GITHUB_ENV
-        gh release download -R ProcursusTeam/ldid -p ldid_macosx_x86_64
-        mv ldid_macosx_x86_64 ldid
-        chmod +x ldid
-        echo "${PWD}" >> $GITHUB_PATH
-        mkdir ${HOME}/include
-        ln -s $(xcrun -sdk macosx --show-sdk-path)/usr/include/xpc ${HOME}/include/xpc
-        ln -s $(xcrun -sdk macosx --show-sdk-path)/usr/include/launch.h ${HOME}/include/launch.h
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup environment
+        run: |
+          echo "CC=xcrun -sdk iphoneos cc -arch arm64" >> $GITHUB_ENV
+          echo "STRIP=xcrun -sdk iphoneos strip" >> $GITHUB_ENV
+          echo "CFLAGS=-I${HOME}/include -Os -flto=thin -miphoneos-version-min=12.0" >> $GITHUB_ENV
+          echo "LDFLAGS=-Os -flto=thin -miphoneos-version-min=12.0" >> $GITHUB_ENV
+          gh release download -R ProcursusTeam/ldid -p ldid_macosx_x86_64
+          install -m755 ldid_macosx_x86_64 ldid
+          echo "${PWD}" >> $GITHUB_PATH
+          mkdir -p ${HOME}/include
+          ln -s $(xcrun -sdk macosx --show-sdk-path)/usr/include/xpc ${HOME}/include/xpc
+          ln -s $(xcrun -sdk macosx --show-sdk-path)/usr/include/launch.h ${HOME}/include/launch.h
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: build
-      run: |
-        make -j$(sysctl -n hw.ncpu)
+      - name: Build
+        run: make -j$(sysctl -n hw.ncpu)
 
-    - uses: actions/upload-artifact@v1
-      with:
-        name: launchctl
-        path: launchctl 
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: launchctl
+          path: launchctl
 
-    - name: Upload Release Asset
-      uses: actions/upload-release-asset@v1
-      if: ${{ github.event_name == 'release' }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: launchctl 
-        asset_name: launchctl 
-        asset_content_type: application/octet-stream
+      - name: Upload to release
+        uses: actions/upload-release-asset@v1
+        if: ${{ github.event_name == 'released '}}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: launchctl
+          asset_name: launchctl
+          asset_content_type: application/octet-stream

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,12 +55,9 @@ jobs:
           path: launchctl
 
       - name: Upload to release
-        uses: actions/upload-release-asset@v1
-        if: ${{ github.event_name == 'released '}}
+        uses: softprops/action-gh-release@v1
+        if: ${{ github.event_name == 'release' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: launchctl
-          asset_name: launchctl
-          asset_content_type: application/octet-stream
+          files: launchctl


### PR DESCRIPTION
This PR introduces the following two changes

- Use updated action workflows: Github recommends using the latest version of actions, particularly those they maintain, as breaking changes for all workflows have been introduced (e.g `actions/checkout@v3`)

- Use a maintained release action: A new action is used to upload artifacts to a new release, since the once previously used was deprecated and archived.