### PR TITLE
Add plist subcommand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ DESTDIR ?=
 
 SRC    := launchctl.c xpc_helper.c start_stop.c print.c env.c load.c manager.c
 SRC    += enable.c reboot.c bootstrap.c error.c remove.c kickstart.c kill.c blame.c
-SRC    += attach.c
+SRC    += attach.c plist.c
 LDLIBS := 
 
 all: launchctl

--- a/TODO.md
+++ b/TODO.md
@@ -10,7 +10,7 @@
 1. [x] print
 1. [x] print-cache
 1. [x] print-disabled
-1. [ ] plist
+1. [x] plist
 1. [ ] procinfo
 1. [ ] hostinfo
 1. [ ] resolveport

--- a/launchctl.c
+++ b/launchctl.c
@@ -65,7 +65,7 @@ static const struct {
 	{ "print", "Prints a description of a domain or service.", "<domain-target> | <service-target>", print_cmd },
 	{ "print-cache", "Prints information about the service cache.", NULL, print_cache_cmd },
 	{ "print-disabled", "Prints which services are disabled.", NULL, print_disabled_cmd },
-	{ "plist", "Prints a property list embedded in a binary (targets the Info.plist by default).", "[segment,section] <path>", todo_cmd },
+	{ "plist", "Prints a property list embedded in a binary (targets the Info.plist by default).", "[segment,section] <path>", plist_cmd },
 	{ "procinfo", "Prints port information about a process.", "<pid>", todo_cmd },
 	{ "hostinfo", "Prints port information about the host.", NULL, todo_cmd },
 	{ "resolveport", "Resolves a port name from a process to an endpoint in launchd.", "<owner-pid> <port-name>", todo_cmd },

--- a/launchctl.c
+++ b/launchctl.c
@@ -1,7 +1,7 @@
 /*-
  * SPDX-License-Identifier: BSD-2-Clause
  *
- * Copyright (c) 2022 Procursus Team <team@procurs.us>
+ * Copyright (c) 2022-2023 Procursus Team <team@procurs.us>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/launchctl.h
+++ b/launchctl.h
@@ -88,6 +88,9 @@ cmd_main managername_cmd;
 // attach.c
 cmd_main attach_cmd;
 
+// plist.c
+cmd_main plist_cmd;
+
 void launchctl_xpc_object_print(xpc_object_t, const char *name, int level);
 int launchctl_send_xpc_to_launchd(uint64_t routine, xpc_object_t msg, xpc_object_t *reply);
 void launchctl_setup_xpc_dict(xpc_object_t dict);

--- a/launchctl.h
+++ b/launchctl.h
@@ -1,7 +1,7 @@
 /*-
  * SPDX-License-Identifier: BSD-2-Clause
  *
- * Copyright (c) 2022 Procursus Team <team@procurs.us>
+ * Copyright (c) 2022-2023 Procursus Team <team@procurs.us>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/plist.c
+++ b/plist.c
@@ -1,7 +1,7 @@
 /*-
  * SPDX-License-Identifier: BSD-2-Clause
  *
- * Copyright (c) 2022 Procursus Team <team@procurs.us>
+ * Copyright (c) 2023 Procursus Team <team@procurs.us>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,331 +25,214 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
-#include <stddef.h>
-#include <stdint.h>
-#include <stdbool.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-#include <errno.h>
 #include <sys/stat.h>
 #include <sys/fcntl.h>
 #include <sys/mman.h>
+
+#include <arpa/inet.h>
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
 #include <mach-o/loader.h>
 #include <mach-o/fat.h>
+
+#include <xpc/xpc.h>
 #include "xpc_private.h"
 
-void launchctl_xpc_object_print(xpc_object_t in, const char *name, int level);
+#include "launchctl.h"
+
+static xpc_object_t
+get_plist_from_section_32(struct mach_header *header, const char *segmentname, const char *sectionname)
+{
+	xpc_object_t plist = NULL;
+
+	uint32_t loadCmdCount = header->ncmds;
+	uintptr_t loadCmdTable = (uintptr_t)header + sizeof(struct mach_header);
+
+	struct load_command *loadCmd = (struct load_command *)loadCmdTable;
+	for (uint32_t j = 0; j < loadCmdCount; j++, loadCmd = (struct load_command *)((uintptr_t)loadCmd + loadCmd->cmdsize)) {
+		if (loadCmd->cmd == LC_SEGMENT) {
+			struct segment_command *segmentCmd = (struct segment_command *)loadCmd;
+			if (strcmp(segmentCmd->segname, segmentname) == 0) {
+				uint32_t sectionCount = segmentCmd->nsects;
+				struct section *sectionTable = (struct section *)((uintptr_t)segmentCmd + sizeof(struct segment_command));
+
+				for (uint32_t k = 0; k < sectionCount; k++) {
+					struct section *section = &(sectionTable[k]);
+					if (strcmp(section->sectname, sectionname) == 0) {
+						size_t dataSize = (size_t)(section->size);
+						void *secdata = (void *)((uintptr_t)header + section->offset);
+						plist = xpc_create_from_plist(secdata, dataSize);
+						if (plist != NULL) {
+							return plist;
+						}
+					}
+				}
+			}
+		}
+	}
+
+	fprintf(stderr, "32-bit Mach-O does not have a %s,%s or is invalid.\n\n", segmentname, sectionname);
+	return NULL;
+}
+
+static xpc_object_t
+get_plist_from_section_64(struct mach_header_64 *header, const char *segmentname, const char *sectionname)
+{
+	xpc_object_t plist = NULL;
+
+	uint32_t loadCmdCount = header->ncmds;
+	uintptr_t loadCmdTable = (uintptr_t)header + sizeof(struct mach_header_64);
+
+	struct load_command *loadCmd = (struct load_command *)loadCmdTable;
+	for (uint32_t j = 0; j < loadCmdCount; j++, loadCmd = (struct load_command *)((uintptr_t)loadCmd + loadCmd->cmdsize)) {
+		if (loadCmd->cmd == LC_SEGMENT_64) {
+			struct segment_command_64 *segmentCmd = (struct segment_command_64 *)loadCmd;
+			if (strcmp(segmentCmd->segname, segmentname) == 0) {
+				uint32_t sectionCount = segmentCmd->nsects;
+				struct section_64 *sectionTable = (struct section_64 *)((uintptr_t)segmentCmd + sizeof(struct segment_command_64));
+
+				for (uint32_t k = 0; k < sectionCount; k++) {
+					struct section_64 *section = &(sectionTable[k]);
+					if (strcmp(section->sectname, sectionname) == 0) {
+						size_t dataSize = (size_t)(section->size);
+						void *secdata = (void *)((uintptr_t)header + section->offset);
+						plist = xpc_create_from_plist(secdata, dataSize);
+						if (plist != NULL) {
+							return plist;
+						}
+					}
+				}
+			}
+		}
+	}
+
+	fprintf(stderr, "64-bit Mach-O does not have a %s,%s or is invalid.\n\n", segmentname, sectionname);
+	return NULL;
+}
 
 int plist_cmd(xpc_object_t *msg, int argc, char **argv, char **envp, char **apple) {
-	int retval = 0;
-    
-    int err = 0;
-    const char *wantedSegment = NULL;
-    const char *wantedSection = NULL;
-    const char *path = NULL;
-    int fd = -1;
-    size_t mappingSize = 0;
-    void *mapping = NULL;
-    xpc_object_t xpcObject = NULL;
-    bool successfullyFound = false;
-    
-    if (argc < 2) {
-        retval = EUSAGE;
-        goto end;
-    }
-    
-    if (argc != 3) {
-        wantedSegment = SEG_TEXT;
-        wantedSection = "__info_plist";
-        path = argv[1];
-    }
-    else {
-        char *specifier = argv[1];
-        
-        char *found = strchr(specifier, ',');
-        if (found == NULL) {
-            retval = EUSAGE;
-            goto end;
-        }
-        
-        *found = 0;
-        
-        wantedSegment = specifier;
-        wantedSection = (char *)((uintptr_t)found + 1);
-        path = argv[2];
-    }
-    
-    fd = open(path, O_RDONLY);
-    if (fd == -1) {
-        fprintf(stderr, "open(): %d: %s\n", errno, strerror(errno));
-        retval = 0;
-        goto end;
-    }
-    
-    struct stat status = {};
-    err = fstat(fd, &status);
-    if (err == -1) {
-        fprintf(stderr, "fdstat(): %d: %s\n", errno, strerror(errno));
-        retval = 0;
-        goto end;
-    }
-    
-    mappingSize = status.st_size;
-    
-    mapping = mmap(NULL, mappingSize, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0);
-    if (mapping == MAP_FAILED) {
-        fprintf(stderr, "mmap(): %d: %s\n", errno, strerror(errno));
-        retval = 0;
-        goto end;
-    }
-    
-    if (mappingSize < sizeof(uint32_t)) {
-        fprintf(stderr, "File is not a valid Mach-O or fat file.\n");
-        retval = 0;
-        goto end;
-    }
-    
-    uint32_t magic = *(uint32_t *)mapping;
-    if (magic == MH_MAGIC) {
-        if (mappingSize < sizeof(struct mach_header)) {
-            fprintf(stderr, "File is not a valid Mach-O or fat file.\n");
-            retval = 0;
-            goto end;
-        }
-        
-        struct mach_header *header = (struct mach_header *)mapping;
-        uint32_t loadCmdCount = header->ncmds;
-        uintptr_t loadCmdTable = (uintptr_t)header + sizeof(struct mach_header);
-        
-        struct load_command *loadCmd = (struct load_command *)loadCmdTable;
-        for (uint32_t j = 0; j < loadCmdCount; j++, loadCmd = (struct load_command *)((uintptr_t)loadCmd + loadCmd->cmdsize)) {
-            if (loadCmd->cmd == LC_SEGMENT) {
-                struct segment_command *segmentCmd = (struct segment_command *)loadCmd;
-                if (strcmp(segmentCmd->segname, wantedSegment) == 0) {
-                    uint32_t sectionCount = segmentCmd->nsects;
-                    struct section *sectionTable = (struct section *)((uintptr_t)segmentCmd + sizeof(struct segment_command));
-                    
-                    bool superbreak = false;
-                    for (uint32_t k = 0; k < sectionCount; k++) {
-                        struct section *section = &(sectionTable[k]);
-                        if (strcmp(section->sectname, wantedSection) == 0) {
-                            size_t dataSize = (size_t)(section->size);
-                            void *data = (void *)((uintptr_t)header + section->offset);
-                            
-                            xpcObject = xpc_create_from_plist(data, dataSize);
-                            if (xpcObject != NULL) {
-                                launchctl_xpc_object_print(xpcObject, NULL, 0);
-                            }
-                            
-                            successfullyFound = true;
-                            superbreak = true;
-                            break;
-                        }
-                    }
-                    if (superbreak) {
-                        break;
-                    }
-                }
-            }
-        }
-        
-        if (!successfullyFound) {
-            fprintf(stderr, "32-bit Mach-O does not have a %s,%s or is invalid.\n\n", wantedSegment, wantedSection);
-            retval = 0;
-            goto end;
-        }
-    }
-    else if (magic == MH_MAGIC_64) {
-        if (mappingSize < sizeof(struct mach_header_64)) {
-            fprintf(stderr, "File is not a valid Mach-O or fat file.\n");
-            retval = 0;
-            goto end;
-        }
-        
-        struct mach_header_64 *header = (struct mach_header_64 *)mapping;
-        uint32_t loadCmdCount = header->ncmds;
-        uintptr_t loadCmdTable = (uintptr_t)header + sizeof(struct mach_header_64);
-        
-        struct load_command *loadCmd = (struct load_command *)loadCmdTable;
-        for (uint32_t j = 0; j < loadCmdCount; j++, loadCmd = (struct load_command *)((uintptr_t)loadCmd + loadCmd->cmdsize)) {
-            if (loadCmd->cmd == LC_SEGMENT_64) {
-                struct segment_command_64 *segmentCmd = (struct segment_command_64 *)loadCmd;
-                if (strcmp(segmentCmd->segname, wantedSegment) == 0) {
-                    uint32_t sectionCount = segmentCmd->nsects;
-                    struct section_64 *sectionTable = (struct section_64 *)((uintptr_t)segmentCmd + sizeof(struct segment_command_64));
-                    
-                    bool superbreak = false;
-                    for (uint32_t k = 0; k < sectionCount; k++) {
-                        struct section_64 *section = &(sectionTable[k]);
-                        if (strcmp(section->sectname, wantedSection) == 0) {
-                            size_t dataSize = (size_t)(section->size);
-                            void *data = (void *)((uintptr_t)header + section->offset);
-                            
-                            xpcObject = xpc_create_from_plist(data, dataSize);
-                            if (xpcObject != NULL) {
-                                launchctl_xpc_object_print(xpcObject, NULL, 0);
-                            }
-                            
-                            successfullyFound = true;
-                            superbreak = true;
-                            break;
-                        }
-                    }
-                    if (superbreak) {
-                        break;
-                    }
-                }
-            }
-        }
-        
-        if (!successfullyFound) {
-            fprintf(stderr, "64-bit Mach-O does not have a %s,%s or is invalid.\n\n", wantedSegment, wantedSection);
-            retval = 0;
-            goto end;
-        }
-    }
-    else if (magic == FAT_CIGAM || magic == FAT_CIGAM_64) {
-        if (mappingSize < sizeof(struct fat_header)) {
-            fprintf(stderr, "File is not a valid Mach-O or fat file.\n");
-            retval = 0;
-            goto end;
-        }
-        
-        struct fat_header *fatHeader = (struct fat_header *)mapping;
-        uint32_t archCount = ntohl(fatHeader->nfat_arch);
-        void *archTable = (void *)((uintptr_t)fatHeader + sizeof(struct fat_header));
-        
-        bool supersuperbreak = false;
-        for (uint32_t i = 0; i < archCount; i++) {
-            void *archMapping = NULL;
-            if (magic == FAT_CIGAM) {
-                struct fat_arch *arch = (struct fat_arch *)((uintptr_t)archTable + (i * sizeof(struct fat_arch)));
-                uint64_t archOffset = ntohl(arch->offset);
-                archMapping = (void *)((uintptr_t)mapping + archOffset);
-            }
-            else if (magic == FAT_CIGAM_64) {
-                struct fat_arch_64 *arch = (struct fat_arch_64 *)((uintptr_t)archTable + (i * sizeof(struct fat_arch_64)));
-                uint64_t archOffset = ntohl(arch->offset);
-                archMapping = (void *)((uintptr_t)mapping + archOffset);
-            }
-            
-            uint32_t archMagic = *(uint32_t *)archMapping;
-            if (archMagic == MH_MAGIC) {
-                struct mach_header *header = (struct mach_header *)archMapping;
-                uint32_t loadCmdCount = header->ncmds;
-                uintptr_t loadCmdTable = (uintptr_t)header + sizeof(struct mach_header);
-                
-                struct load_command *loadCmd = (struct load_command *)loadCmdTable;
-                for (uint32_t j = 0; j < loadCmdCount; j++, loadCmd = (struct load_command *)((uintptr_t)loadCmd + loadCmd->cmdsize)) {
-                    if (loadCmd->cmd == LC_SEGMENT) {
-                        struct segment_command *segmentCmd = (struct segment_command *)loadCmd;
-                        if (strcmp(segmentCmd->segname, wantedSegment) == 0) {
-                            uint32_t sectionCount = segmentCmd->nsects;
-                            struct section *sectionTable = (struct section *)((uintptr_t)segmentCmd + sizeof(struct segment_command));
-                            
-                            bool superbreak = false;
-                            for (uint32_t k = 0; k < sectionCount; k++) {
-                                struct section *section = &(sectionTable[k]);
-                                if (strcmp(section->sectname, wantedSection) == 0) {
-                                    size_t dataSize = (size_t)(section->size);
-                                    void *data = (void *)((uintptr_t)header + section->offset);
-                                    
-                                    xpcObject = xpc_create_from_plist(data, dataSize);
-                                    if (xpcObject != NULL) {
-                                        launchctl_xpc_object_print(xpcObject, NULL, 0);
-                                    }
-                                    
-                                    successfullyFound = true;
-                                    superbreak = true;
-                                    supersuperbreak = true;
-                                    break;
-                                }
-                            }
-                            if (superbreak) {
-                                break;
-                            }
-                        }
-                    }
-                }
-                
-                if (!successfullyFound) {
-                    fprintf(stderr, "32-bit Mach-O does not have a %s,%s or is invalid.\n\n", wantedSegment, wantedSection);
-                    retval = 0;
-                    goto end;
-                }
-            }
-            else if (archMagic == MH_MAGIC_64) {
-                struct mach_header_64 *header = (struct mach_header_64 *)archMapping;
-                uint32_t loadCmdCount = header->ncmds;
-                uintptr_t loadCmdTable = (uintptr_t)header + sizeof(struct mach_header_64);
-                
-                struct load_command *loadCmd = (struct load_command *)loadCmdTable;
-                for (uint32_t j = 0; j < loadCmdCount; j++, loadCmd = (struct load_command *)((uintptr_t)loadCmd + loadCmd->cmdsize)) {
-                    if (loadCmd->cmd == LC_SEGMENT_64) {
-                        struct segment_command_64 *segmentCmd = (struct segment_command_64 *)loadCmd;
-                        if (strcmp(segmentCmd->segname, wantedSegment) == 0) {
-                            uint32_t sectionCount = segmentCmd->nsects;
-                            struct section_64 *sectionTable = (struct section_64 *)((uintptr_t)segmentCmd + sizeof(struct segment_command_64));
-                            
-                            bool superbreak = false;
-                            for (uint32_t k = 0; k < sectionCount; k++) {
-                                struct section_64 *section = &(sectionTable[k]);
-                                if (strcmp(section->sectname, wantedSection) == 0) {
-                                    size_t dataSize = (size_t)(section->size);
-                                    void *data = (void *)((uintptr_t)header + section->offset);
-                                    
-                                    xpcObject = xpc_create_from_plist(data, dataSize);
-                                    if (xpcObject != NULL) {
-                                        launchctl_xpc_object_print(xpcObject, NULL, 0);
-                                    }
-                                    
-                                    successfullyFound = true;
-                                    superbreak = true;
-                                    supersuperbreak = true;
-                                    break;
-                                }
-                            }
-                            if (superbreak) {
-                                break;
-                            }
-                        }
-                    }
-                }
-                if (supersuperbreak) {
-                    break;
-                }
-                
-                if (!successfullyFound) {
-                    fprintf(stderr, "64-bit Mach-O does not have a %s,%s or is invalid.\n\n", wantedSegment, wantedSection);
-                    retval = 0;
-                    goto end;
-                }
-            }
-        }
-        if (!successfullyFound) {
-            fprintf(stderr, "Fat file does not contain valid architectures.\n");
-            retval = 0;
-            goto end;
-        }
-    }
-    else {
-        fprintf(stderr, "File is not a valid Mach-O or fat file.\n");
-        retval = 0;
-        goto end;
-    }
-    
+	int err = 0;
+	const char *wantedSegment = NULL;
+	const char *wantedSection = NULL;
+	const char *path = NULL;
+	int fd = -1;
+	size_t mappingSize = 0;
+	void *mapping = NULL;
+	xpc_object_t plist = NULL;
+	bool successfullyFound = false;
+
+	if (argc < 2) {
+		return EUSAGE;
+	}
+
+	if (argc != 3) {
+		wantedSegment = SEG_TEXT;
+		wantedSection = "__info_plist";
+		path = argv[1];
+	} else {
+		char *specifier = argv[1];
+		char *found = strchr(specifier, ',');
+		if (found == NULL) {
+			return EUSAGE;
+		}
+		*found = 0;
+		wantedSegment = specifier;
+		wantedSection = (char *)((uintptr_t)found + 1);
+		path = argv[2];
+	}
+
+	fd = open(path, O_RDONLY);
+	if (fd == -1) {
+		fprintf(stderr, "open(): %d: %s\n", errno, strerror(errno));
+		goto end;
+	}
+
+	struct stat status = {};
+	err = fstat(fd, &status);
+	if (err == -1) {
+		fprintf(stderr, "fdstat(): %d: %s\n", errno, strerror(errno));
+		goto end;
+	}
+
+	mappingSize = status.st_size;
+
+	mapping = mmap(NULL, mappingSize, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0);
+	if (mapping == MAP_FAILED) {
+		fprintf(stderr, "mmap(): %d: %s\n", errno, strerror(errno));
+		goto end;
+	}
+
+	if (mappingSize < sizeof(uint32_t) && mappingSize < sizeof(struct mach_header) && mappingSize < sizeof(struct mach_header_64) && mappingSize < sizeof(struct fat_header)) {
+		fprintf(stderr, "File is not a valid Mach-O or fat file.\n");
+		goto end;
+	}
+
+	uint32_t magic = *(uint32_t *)mapping;
+	if (magic == MH_MAGIC) {
+		plist = get_plist_from_section_32(mapping, wantedSegment, wantedSection);
+	} else if (magic == MH_MAGIC_64) {
+		plist = get_plist_from_section_64(mapping, wantedSegment, wantedSection);
+	} else if (magic == FAT_CIGAM || magic == FAT_CIGAM_64) {
+		struct fat_header *fatHeader = (struct fat_header *)mapping;
+		uint32_t archCount = ntohl(fatHeader->nfat_arch);
+		void *archTable = (void *)((uintptr_t)fatHeader + sizeof(struct fat_header));
+
+		for (uint32_t i = 0; i < archCount; i++) {
+			void *archMapping = NULL;
+			if (magic == FAT_CIGAM) {
+				struct fat_arch *arch = (struct fat_arch *)((uintptr_t)archTable + (i * sizeof(struct fat_arch)));
+				uint64_t archOffset = ntohl(arch->offset);
+				archMapping = (void *)((uintptr_t)mapping + archOffset);
+			} else if (magic == FAT_CIGAM_64) {
+				struct fat_arch_64 *arch = (struct fat_arch_64 *)((uintptr_t)archTable + (i * sizeof(struct fat_arch_64)));
+				uint64_t archOffset = ntohl(arch->offset);
+				archMapping = (void *)((uintptr_t)mapping + archOffset);
+			}
+
+			uint32_t archMagic = *(uint32_t *)archMapping;
+			if (archMagic == MH_MAGIC) {
+				plist = get_plist_from_section_32(archMapping, wantedSegment, wantedSection);
+				if (plist != NULL) {
+					goto print;
+				} else {
+					goto end;
+				}
+			} else if (archMagic == MH_MAGIC_64) {
+				plist = get_plist_from_section_64(archMapping, wantedSegment, wantedSection);
+				if (plist != NULL) {
+					goto print;
+				} else {
+					goto end;
+				}
+			}
+		}
+		fprintf(stderr, "Fat file does not contain valid architectures.\n");
+		goto end;
+	} else {
+		fprintf(stderr, "File is not a valid Mach-O or fat file.\n");
+		goto end;
+	}
+
+print:
+	launchctl_xpc_object_print(plist, NULL, 0);
+
 end:
-    if (xpcObject != NULL) {
-        xpc_release(xpcObject);
-    }
-    if (mapping != NULL) {
-        munmap(mapping, mappingSize);
-    }
-    if (fd != -1) {
-        close(fd);
-    }
-    
-	return retval;
+	if (plist != NULL) {
+		xpc_release(plist);
+	}
+	if (mapping != NULL) {
+		munmap(mapping, mappingSize);
+	}
+	if (fd != -1) {
+		close(fd);
+	}
+
+	return 0;
 }

--- a/plist.c
+++ b/plist.c
@@ -1,0 +1,355 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2022 Procursus Team <team@procurs.us>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/stat.h>
+#include <sys/fcntl.h>
+#include <sys/mman.h>
+#include <mach-o/loader.h>
+#include <mach-o/fat.h>
+#include "xpc_private.h"
+
+void launchctl_xpc_object_print(xpc_object_t in, const char *name, int level);
+
+int plist_cmd(xpc_object_t *msg, int argc, char **argv, char **envp, char **apple) {
+	int retval = 0;
+    
+    int err = 0;
+    const char *wantedSegment = NULL;
+    const char *wantedSection = NULL;
+    const char *path = NULL;
+    int fd = -1;
+    size_t mappingSize = 0;
+    void *mapping = NULL;
+    xpc_object_t xpcObject = NULL;
+    bool successfullyFound = false;
+    
+    if (argc < 2) {
+        retval = EUSAGE;
+        goto end;
+    }
+    
+    if (argc != 3) {
+        wantedSegment = SEG_TEXT;
+        wantedSection = "__info_plist";
+        path = argv[1];
+    }
+    else {
+        char *specifier = argv[1];
+        
+        char *found = strchr(specifier, ',');
+        if (found == NULL) {
+            retval = EUSAGE;
+            goto end;
+        }
+        
+        *found = 0;
+        
+        wantedSegment = specifier;
+        wantedSection = (char *)((uintptr_t)found + 1);
+        path = argv[2];
+    }
+    
+    fd = open(path, O_RDONLY);
+    if (fd == -1) {
+        fprintf(stderr, "open(): %d: %s\n", errno, strerror(errno));
+        retval = 0;
+        goto end;
+    }
+    
+    struct stat status = {};
+    err = fstat(fd, &status);
+    if (err == -1) {
+        fprintf(stderr, "fdstat(): %d: %s\n", errno, strerror(errno));
+        retval = 0;
+        goto end;
+    }
+    
+    mappingSize = status.st_size;
+    
+    mapping = mmap(NULL, mappingSize, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0);
+    if (mapping == MAP_FAILED) {
+        fprintf(stderr, "mmap(): %d: %s\n", errno, strerror(errno));
+        retval = 0;
+        goto end;
+    }
+    
+    if (mappingSize < sizeof(uint32_t)) {
+        fprintf(stderr, "File is not a valid Mach-O or fat file.\n");
+        retval = 0;
+        goto end;
+    }
+    
+    uint32_t magic = *(uint32_t *)mapping;
+    if (magic == MH_MAGIC) {
+        if (mappingSize < sizeof(struct mach_header)) {
+            fprintf(stderr, "File is not a valid Mach-O or fat file.\n");
+            retval = 0;
+            goto end;
+        }
+        
+        struct mach_header *header = (struct mach_header *)mapping;
+        uint32_t loadCmdCount = header->ncmds;
+        uintptr_t loadCmdTable = (uintptr_t)header + sizeof(struct mach_header);
+        
+        struct load_command *loadCmd = (struct load_command *)loadCmdTable;
+        for (uint32_t j = 0; j < loadCmdCount; j++, loadCmd = (struct load_command *)((uintptr_t)loadCmd + loadCmd->cmdsize)) {
+            if (loadCmd->cmd == LC_SEGMENT) {
+                struct segment_command *segmentCmd = (struct segment_command *)loadCmd;
+                if (strcmp(segmentCmd->segname, wantedSegment) == 0) {
+                    uint32_t sectionCount = segmentCmd->nsects;
+                    struct section *sectionTable = (struct section *)((uintptr_t)segmentCmd + sizeof(struct segment_command));
+                    
+                    bool superbreak = false;
+                    for (uint32_t k = 0; k < sectionCount; k++) {
+                        struct section *section = &(sectionTable[k]);
+                        if (strcmp(section->sectname, wantedSection) == 0) {
+                            size_t dataSize = (size_t)(section->size);
+                            void *data = (void *)((uintptr_t)header + section->offset);
+                            
+                            xpcObject = xpc_create_from_plist(data, dataSize);
+                            if (xpcObject != NULL) {
+                                launchctl_xpc_object_print(xpcObject, NULL, 0);
+                            }
+                            
+                            successfullyFound = true;
+                            superbreak = true;
+                            break;
+                        }
+                    }
+                    if (superbreak) {
+                        break;
+                    }
+                }
+            }
+        }
+        
+        if (!successfullyFound) {
+            fprintf(stderr, "32-bit Mach-O does not have a %s,%s or is invalid.\n\n", wantedSegment, wantedSection);
+            retval = 0;
+            goto end;
+        }
+    }
+    else if (magic == MH_MAGIC_64) {
+        if (mappingSize < sizeof(struct mach_header_64)) {
+            fprintf(stderr, "File is not a valid Mach-O or fat file.\n");
+            retval = 0;
+            goto end;
+        }
+        
+        struct mach_header_64 *header = (struct mach_header_64 *)mapping;
+        uint32_t loadCmdCount = header->ncmds;
+        uintptr_t loadCmdTable = (uintptr_t)header + sizeof(struct mach_header_64);
+        
+        struct load_command *loadCmd = (struct load_command *)loadCmdTable;
+        for (uint32_t j = 0; j < loadCmdCount; j++, loadCmd = (struct load_command *)((uintptr_t)loadCmd + loadCmd->cmdsize)) {
+            if (loadCmd->cmd == LC_SEGMENT_64) {
+                struct segment_command_64 *segmentCmd = (struct segment_command_64 *)loadCmd;
+                if (strcmp(segmentCmd->segname, wantedSegment) == 0) {
+                    uint32_t sectionCount = segmentCmd->nsects;
+                    struct section_64 *sectionTable = (struct section_64 *)((uintptr_t)segmentCmd + sizeof(struct segment_command_64));
+                    
+                    bool superbreak = false;
+                    for (uint32_t k = 0; k < sectionCount; k++) {
+                        struct section_64 *section = &(sectionTable[k]);
+                        if (strcmp(section->sectname, wantedSection) == 0) {
+                            size_t dataSize = (size_t)(section->size);
+                            void *data = (void *)((uintptr_t)header + section->offset);
+                            
+                            xpcObject = xpc_create_from_plist(data, dataSize);
+                            if (xpcObject != NULL) {
+                                launchctl_xpc_object_print(xpcObject, NULL, 0);
+                            }
+                            
+                            successfullyFound = true;
+                            superbreak = true;
+                            break;
+                        }
+                    }
+                    if (superbreak) {
+                        break;
+                    }
+                }
+            }
+        }
+        
+        if (!successfullyFound) {
+            fprintf(stderr, "64-bit Mach-O does not have a %s,%s or is invalid.\n\n", wantedSegment, wantedSection);
+            retval = 0;
+            goto end;
+        }
+    }
+    else if (magic == FAT_CIGAM || magic == FAT_CIGAM_64) {
+        if (mappingSize < sizeof(struct fat_header)) {
+            fprintf(stderr, "File is not a valid Mach-O or fat file.\n");
+            retval = 0;
+            goto end;
+        }
+        
+        struct fat_header *fatHeader = (struct fat_header *)mapping;
+        uint32_t archCount = ntohl(fatHeader->nfat_arch);
+        void *archTable = (void *)((uintptr_t)fatHeader + sizeof(struct fat_header));
+        
+        bool supersuperbreak = false;
+        for (uint32_t i = 0; i < archCount; i++) {
+            void *archMapping = NULL;
+            if (magic == FAT_CIGAM) {
+                struct fat_arch *arch = (struct fat_arch *)((uintptr_t)archTable + (i * sizeof(struct fat_arch)));
+                uint64_t archOffset = ntohl(arch->offset);
+                archMapping = (void *)((uintptr_t)mapping + archOffset);
+            }
+            else if (magic == FAT_CIGAM_64) {
+                struct fat_arch_64 *arch = (struct fat_arch_64 *)((uintptr_t)archTable + (i * sizeof(struct fat_arch_64)));
+                uint64_t archOffset = ntohl(arch->offset);
+                archMapping = (void *)((uintptr_t)mapping + archOffset);
+            }
+            
+            uint32_t archMagic = *(uint32_t *)archMapping;
+            if (archMagic == MH_MAGIC) {
+                struct mach_header *header = (struct mach_header *)archMapping;
+                uint32_t loadCmdCount = header->ncmds;
+                uintptr_t loadCmdTable = (uintptr_t)header + sizeof(struct mach_header);
+                
+                struct load_command *loadCmd = (struct load_command *)loadCmdTable;
+                for (uint32_t j = 0; j < loadCmdCount; j++, loadCmd = (struct load_command *)((uintptr_t)loadCmd + loadCmd->cmdsize)) {
+                    if (loadCmd->cmd == LC_SEGMENT) {
+                        struct segment_command *segmentCmd = (struct segment_command *)loadCmd;
+                        if (strcmp(segmentCmd->segname, wantedSegment) == 0) {
+                            uint32_t sectionCount = segmentCmd->nsects;
+                            struct section *sectionTable = (struct section *)((uintptr_t)segmentCmd + sizeof(struct segment_command));
+                            
+                            bool superbreak = false;
+                            for (uint32_t k = 0; k < sectionCount; k++) {
+                                struct section *section = &(sectionTable[k]);
+                                if (strcmp(section->sectname, wantedSection) == 0) {
+                                    size_t dataSize = (size_t)(section->size);
+                                    void *data = (void *)((uintptr_t)header + section->offset);
+                                    
+                                    xpcObject = xpc_create_from_plist(data, dataSize);
+                                    if (xpcObject != NULL) {
+                                        launchctl_xpc_object_print(xpcObject, NULL, 0);
+                                    }
+                                    
+                                    successfullyFound = true;
+                                    superbreak = true;
+                                    supersuperbreak = true;
+                                    break;
+                                }
+                            }
+                            if (superbreak) {
+                                break;
+                            }
+                        }
+                    }
+                }
+                
+                if (!successfullyFound) {
+                    fprintf(stderr, "32-bit Mach-O does not have a %s,%s or is invalid.\n\n", wantedSegment, wantedSection);
+                    retval = 0;
+                    goto end;
+                }
+            }
+            else if (archMagic == MH_MAGIC_64) {
+                struct mach_header_64 *header = (struct mach_header_64 *)archMapping;
+                uint32_t loadCmdCount = header->ncmds;
+                uintptr_t loadCmdTable = (uintptr_t)header + sizeof(struct mach_header_64);
+                
+                struct load_command *loadCmd = (struct load_command *)loadCmdTable;
+                for (uint32_t j = 0; j < loadCmdCount; j++, loadCmd = (struct load_command *)((uintptr_t)loadCmd + loadCmd->cmdsize)) {
+                    if (loadCmd->cmd == LC_SEGMENT_64) {
+                        struct segment_command_64 *segmentCmd = (struct segment_command_64 *)loadCmd;
+                        if (strcmp(segmentCmd->segname, wantedSegment) == 0) {
+                            uint32_t sectionCount = segmentCmd->nsects;
+                            struct section_64 *sectionTable = (struct section_64 *)((uintptr_t)segmentCmd + sizeof(struct segment_command_64));
+                            
+                            bool superbreak = false;
+                            for (uint32_t k = 0; k < sectionCount; k++) {
+                                struct section_64 *section = &(sectionTable[k]);
+                                if (strcmp(section->sectname, wantedSection) == 0) {
+                                    size_t dataSize = (size_t)(section->size);
+                                    void *data = (void *)((uintptr_t)header + section->offset);
+                                    
+                                    xpcObject = xpc_create_from_plist(data, dataSize);
+                                    if (xpcObject != NULL) {
+                                        launchctl_xpc_object_print(xpcObject, NULL, 0);
+                                    }
+                                    
+                                    successfullyFound = true;
+                                    superbreak = true;
+                                    supersuperbreak = true;
+                                    break;
+                                }
+                            }
+                            if (superbreak) {
+                                break;
+                            }
+                        }
+                    }
+                }
+                if (supersuperbreak) {
+                    break;
+                }
+                
+                if (!successfullyFound) {
+                    fprintf(stderr, "64-bit Mach-O does not have a %s,%s or is invalid.\n\n", wantedSegment, wantedSection);
+                    retval = 0;
+                    goto end;
+                }
+            }
+        }
+        if (!successfullyFound) {
+            fprintf(stderr, "Fat file does not contain valid architectures.\n");
+            retval = 0;
+            goto end;
+        }
+    }
+    else {
+        fprintf(stderr, "File is not a valid Mach-O or fat file.\n");
+        retval = 0;
+        goto end;
+    }
+    
+end:
+    if (xpcObject != NULL) {
+        xpc_release(xpcObject);
+    }
+    if (mapping != NULL) {
+        munmap(mapping, mappingSize);
+    }
+    if (fd != -1) {
+        close(fd);
+    }
+    
+	return retval;
+}


### PR DESCRIPTION
Adds the `launchctl plist` subcommand. 

This is the closest I can get to a 1:1 copy, but it is still not completely 1:1. More specifically, the "no error occurred" cases are indeed 1:1, but the "error occurred" cases, especially edge cases, are not completely 1:1. ¯\_(ツ)_/¯