### PR TITLE
Add unimplemented uncache

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,7 @@
 1. [x] bootout
 1. [x] enable
 1. [x] disable
+1. [x] uncache
 1. [x] kickstart
 1. [x] attach
 1. [ ] debug

--- a/launchctl.c
+++ b/launchctl.c
@@ -62,6 +62,7 @@ static const struct {
 	{ "bootout", "Tears down a domain or removes a service from a domain.", "<domain-target> [service-path1, service-path2, ...] | <service-target>", bootout_cmd },
 	{ "enable", "Enables an existing service.", "<service-target>", enable_cmd },
 	{ "disable", "Disables an existing service.", "<service-target>", enable_cmd },
+	{ "uncache", "Removes the specified service name from the service cache.", "<service-name>", uncache_cmd },
 	{ "kickstart", "Forces an existing service to start.", "[-k] [-p] <service-target>", kickstart_cmd },
 	{ "attach", "Attach the system's debugger to a service.", "[-k] [-s] [-x] <service-target>", attach_cmd },
 	{ "debug", "Configures the next invocation of a service for debugging.", "<service-target> [--program <program-path>] [--start-suspended] [oc-stack-logging] [--malloc-nano-allocator] [--debug-libraries] [--NSZombie] [--32] [--stdin [path]] [--stdout [path]] [--stderr [path]] [--environment VARIABLE0=value0 VARIABLE1=value1 ...] -- [argv0 argv1 ...]", todo_cmd },
@@ -217,6 +218,12 @@ int
 submit_cmd(xpc_object_t *msg, int argc, char **argv, char **envp, char **apple)
 {
 	return EDEPRECATED;
+}
+
+int
+uncache_cmd(xpc_object_t *msg, int argc, char **argv, char **envp, char **apple)
+{
+	return E2BIMPL;
 }
 
 int

--- a/launchctl.h
+++ b/launchctl.h
@@ -41,6 +41,7 @@ typedef int cmd_main(xpc_object_t *, int, char **, char **, char **);
 cmd_main help_cmd;
 cmd_main config_cmd;
 cmd_main submit_cmd;
+cmd_main uncache_cmd;
 cmd_main todo_cmd; // Placeholder
 
 // version.c


### PR DESCRIPTION
This PR adds unimplemented uncache subcommand, in the same way the previous Apple launchctl binaries on Procursus did it.